### PR TITLE
Fixes thejsn/react-image-mosaic#3

### DIFF
--- a/src/models/Grid.ts
+++ b/src/models/Grid.ts
@@ -12,7 +12,7 @@ class Grid {
 
     _colors: number[] = [];
     _gridColors: number[] = [];
-    _pictures = new Map<number, Picture | undefined>();
+    _pictures = new Map<number, Picture>();
 
     _canvas: HTMLCanvasElement | null = null;
     _context: CanvasRenderingContext2D | null = null;
@@ -93,9 +93,11 @@ class Grid {
     /**
 	 * Returns a Picture with the average
 	 * color that closest matches given color.
+     * "using as Picture" because Map.get can theoretically return undefined,
+     * but not if we using .getClosestColor as key
 	 */
-    getPictureByColor(color: number): Picture | undefined {
-        return this._pictures.get(this.getClosestColor(color));
+    getPictureByColor(color: number): Picture {
+        return this._pictures.get(this.getClosestColor(color)) as Picture;
     }
 
     //---------------------------------------
@@ -203,7 +205,7 @@ class Grid {
         // Iterate over _pictures Map
         this._pictures.forEach((picture, color) => {
 
-            if (picture?.src === url) {
+            if (picture.src === url) {
 
                 //remove color from colors array
                 const pos = this._colors.indexOf(color);
@@ -242,7 +244,7 @@ class Grid {
             this.resetGridSquares();
 
             const blending = this._colorBlending;
-            let pic: Picture | undefined = undefined;
+            let pic: Picture | null = null;
 
             let i = 0, // index
                 j = 0, // pixel position (ix4)
@@ -278,7 +280,7 @@ class Grid {
                 if (blending < 1) {
                     pic = this.getPictureByColor(color);
                     ctx.drawImage(
-                        pic?.canvas as CanvasImageSource,
+                        pic.canvas as CanvasImageSource,
                         x, y, w, h
                     );
                 }

--- a/src/models/Grid.ts
+++ b/src/models/Grid.ts
@@ -12,7 +12,7 @@ class Grid {
 
     _colors: number[] = [];
     _gridColors: number[] = [];
-    _pictures = new Map();
+    _pictures = new Map<number, Picture | undefined>();
 
     _canvas: HTMLCanvasElement | null = null;
     _context: CanvasRenderingContext2D | null = null;
@@ -22,7 +22,7 @@ class Grid {
 
     /**
 	 * Creates an instance of Grid.
-	 * 
+	 *
 	 * @memberOf Grid
 	 */
     constructor() {
@@ -91,10 +91,10 @@ class Grid {
     }
 
     /**
-	 * Returns a Picture with the average 
+	 * Returns a Picture with the average
 	 * color that closest matches given color.
 	 */
-    getPictureByColor(color: number): Picture {
+    getPictureByColor(color: number): Picture | undefined {
         return this._pictures.get(this.getClosestColor(color));
     }
 
@@ -166,7 +166,7 @@ class Grid {
 
             const color = this._colors[i];
 
-            this._pictures.get(color).setSize(
+            this._pictures.get(color)?.setSize(
                 Math.floor(this._width / this._columns),
                 Math.floor(this._height / this._rows)
             );
@@ -195,6 +195,29 @@ class Grid {
     }
 
     /**
+	 * Remove from pool of pictures to not be used in mosaic anymore.
+	 * @param {string} url Picture url to remove
+	 */
+    removeSourceImage(url: string) {
+
+        // Iterate over _pictures Map
+        this._pictures.forEach((picture, color) => {
+
+            if (picture?.src === url) {
+
+                //remove color from colors array
+                const pos = this._colors.indexOf(color);
+                if (pos !== -1) {
+                    this._colors.splice(pos, 1);
+                }
+
+                //remove image from pictures Map
+                this._pictures.delete(color);
+            }
+        });
+    }
+
+    /**
 	 * Draw images to grid.
 	 */
     drawGrid(target:Picture): Promise<void> {
@@ -219,7 +242,7 @@ class Grid {
             this.resetGridSquares();
 
             const blending = this._colorBlending;
-            let pic: Picture | null = null;
+            let pic: Picture | undefined = undefined;
 
             let i = 0, // index
                 j = 0, // pixel position (ix4)
@@ -255,7 +278,7 @@ class Grid {
                 if (blending < 1) {
                     pic = this.getPictureByColor(color);
                     ctx.drawImage(
-                        pic.canvas as CanvasImageSource,
+                        pic?.canvas as CanvasImageSource,
                         x, y, w, h
                     );
                 }

--- a/src/models/Picture.ts
+++ b/src/models/Picture.ts
@@ -11,12 +11,12 @@ export default class Picture {
 
     /**
 	 * Creates an instance of Picture.
-	 * 
-	 * @param {any} image 
-	 * @param {number} [width=10] 
-	 * @param {number} [height=10] 
-	 * @param {number} [aspectRatio=1] 
-	 * 
+	 *
+	 * @param {any} image
+	 * @param {number} [width=10]
+	 * @param {number} [height=10]
+	 * @param {number} [aspectRatio=1]
+	 *
 	 * @memberOf Picture
 	 */
     constructor(image: HTMLImageElement, width = 10, height = 10, aspectRatio = 1) {
@@ -46,9 +46,9 @@ export default class Picture {
     //---------------------------------------
 
     /**
-	 * Get image dimensions based on source image 
+	 * Get image dimensions based on source image
 	 * and dimensions of grid square.
-	 * 
+	 *
 	 * @return {Object} Object with size data.
 	 */
     _getBounds(image: HTMLImageElement) {
@@ -94,9 +94,9 @@ export default class Picture {
 
     /**
 	 * Draws image to virtual canvas which is used to retrieve pixels.
-	 * 
-	 * @returns 
-	 * 
+	 *
+	 * @returns
+	 *
 	 * @memberOf Picture
 	 */
     _drawImage() {
@@ -122,11 +122,11 @@ export default class Picture {
     }
 
     /**
-	 * Loops through all colors, adds all channels together 
+	 * Loops through all colors, adds all channels together
 	 * then returns it as a color value.
-	 * 
+	 *
 	 * @returns {number} The color.
-	 * 
+	 *
 	 * @memberOf Picture
 	 */
     _calculateAverageColor(pixels: Uint8ClampedArray | undefined) {
@@ -182,13 +182,17 @@ export default class Picture {
         return this._image;
     }
 
+    get src() {
+        return this._image?.src || null
+    }
+
     //---------------------------------------
     // Public methods
     //---------------------------------------
 
     /**
 	 * This will redraw the image. Avoid this in loops/raf.
-	 * 
+	 *
 	 * @param {Number} width  New width.
 	 * @param {Number} height New height.
 	 */
@@ -210,9 +214,9 @@ export default class Picture {
 
     /**
 	 * Returns an array of pixeldata.
-	 * 
+	 *
 	 * @returns {Uint8ClampedArray}
-	 * 
+	 *
 	 * @memberOf Picture
 	 */
     getImageData() {
@@ -221,9 +225,9 @@ export default class Picture {
 
     /**
 	 * Set image to do analysis on. Image source must be loaded.
-	 * 
-	 * @param {Image} image 
-	 * 
+	 *
+	 * @param {Image} image
+	 *
 	 * @memberOf Picture
 	 */
     setImage(image: HTMLImageElement) {

--- a/src/utils/sources.ts
+++ b/src/utils/sources.ts
@@ -37,12 +37,11 @@ export function removeSourcesByURL(sources: string[]) {
         Grid.removeSourceImage(img);
      });
 
-    addSourcesFromURL(toAdd, onProgress, onComplete);
 }
 
 /**
  * Add image to be used in the grid from URL.
- * 
+ *
  * @param {String} url Path to image
  */
 export function addSourcesFromURL(

--- a/src/utils/sources.ts
+++ b/src/utils/sources.ts
@@ -11,12 +11,31 @@ export function updateSources(
 
     const toAdd = sources.filter(source => currentSources.indexOf(source) === -1);
 
-    // TODO: Implement support in Grid...
-    // const toRemove = currentSources.filter(
-    //     source => sources.indexOf(source) === -1
-    // );
+    const toRemove = currentSources.filter(current=>sources.indexOf(current)===-1);
 
     currentSources = sources;
+
+    addSourcesFromURL(toAdd, onProgress, onComplete);
+    removeSourcesByURL(toRemove);
+}
+
+/**
+ * Remove image from the grid by URL.
+ *
+ * @param {String} url Path or link to image
+ */
+export function removeSourcesByURL(sources: string[]) {
+
+    // Creates absolute urls (if source is a relative path) to test against picture.image.src
+    const urls = sources.map(path => {
+        const a = document.createElement('a');
+        a.href = path;
+        return a.href;
+    });
+
+    urls.forEach(img => {
+        Grid.removeSourceImage(img);
+     });
 
     addSourcesFromURL(toAdd, onProgress, onComplete);
 }

--- a/types/models/Grid.d.ts
+++ b/types/models/Grid.d.ts
@@ -7,7 +7,7 @@ declare class Grid {
     _rows: number;
     _colors: number[];
     _gridColors: number[];
-    _pictures: Map<any, any>;
+    _pictures: Map<number, Picture>;
     _canvas: HTMLCanvasElement | null;
     _context: CanvasRenderingContext2D | null;
     _hasSuccessfulPaint: boolean;
@@ -52,6 +52,11 @@ declare class Grid {
      * @param {HTMLImageElement} image A Picture
      */
     addSourceImage(image: HTMLImageElement): void;
+    /**
+     * Remove from pool of pictures to not be used in mosaic anymore.
+     * @param {string} url Picture url to remove
+     */
+    removeSourceImage(url: string): void;
     /**
      * Draw images to grid.
      */

--- a/types/models/Picture.d.ts
+++ b/types/models/Picture.d.ts
@@ -56,6 +56,7 @@ export default class Picture {
     get context(): CanvasRenderingContext2D | null;
     get averageColor(): number;
     get image(): HTMLImageElement | null;
+    get src(): string | null;
     /**
      * This will redraw the image. Avoid this in loops/raf.
      *

--- a/types/utils/sources.d.ts
+++ b/types/utils/sources.d.ts
@@ -4,6 +4,12 @@ export declare function updateSources(sources: string[], onProgress: {
     (): void;
 }): void;
 /**
+ * Remove image from the grid by URL.
+ *
+ * @param {String} url Path or link to image
+ */
+export declare function removeSourcesByURL(sources: string[]): void;
+/**
  * Add image to be used in the grid from URL.
  *
  * @param {String} url Path to image


### PR DESCRIPTION
I added changes you suggested

Tested using modified local demo, and it seems like it swaps sources arrays correctly now!

Quick explanation: 
- Added explicit _pictures Map types (to get helpful autocomplete later)
- Created a removeSourceImage(url: string) method in Grid.ts
- Added src getter in Picture.ts
- Addded removeSourcesByURL(sources: string[]) method in sources.ts

I'm sorry for deletion of spaces at the end of some comments, but VS Code is using some formatting magic that I cannot turn off...