### PR TITLE
[Hotfix] Check if pic is undefined

### DIFF
--- a/src/models/Grid.ts
+++ b/src/models/Grid.ts
@@ -279,10 +279,12 @@ class Grid {
 
                 if (blending < 1) {
                     pic = this.getPictureByColor(color);
-                    ctx.drawImage(
-                        pic.canvas as CanvasImageSource,
-                        x, y, w, h
-                    );
+                    if(pic){
+                        ctx.drawImage(
+                            pic.canvas as CanvasImageSource,
+                            x, y, w, h
+                        );
+                    }
                 }
 
                 if (blending > 0) {

--- a/src/models/Grid.ts
+++ b/src/models/Grid.ts
@@ -189,11 +189,14 @@ class Grid {
 
         const color = picture.averageColor;
 
+        // If this color is not already present
+        if (!this._pictures.has(color)) {
+            // Save color in array for quick search later.
+            this._colors.push(color);
+        }
         // The average color of the image is its key.
         this._pictures.set(color, picture);
 
-        // Save color in array for quick search later.
-        this._colors.push(color);
     }
 
     /**
@@ -279,12 +282,10 @@ class Grid {
 
                 if (blending < 1) {
                     pic = this.getPictureByColor(color);
-                    if(pic){
-                        ctx.drawImage(
-                            pic.canvas as CanvasImageSource,
-                            x, y, w, h
-                        );
-                    }
+                    ctx.drawImage(
+                        pic.canvas as CanvasImageSource,
+                        x, y, w, h
+                    );
                 }
 
                 if (blending > 0) {


### PR DESCRIPTION
Encountered this when loading large source arrays
(will keep this in mind when testing in future)

![image](https://github.com/thejsn/react-image-mosaic/assets/19977559/e33aa5b6-7b5a-45c0-868d-0c264d683bc4)
